### PR TITLE
updates from template

### DIFF
--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -14,6 +14,7 @@ jobs:
   document:
     name: "Document"
     runs-on: ubuntu-latest
+    if: ${{ github.triggering_actor != 'dependabot[bot]' }}
     defaults:
       run:
         shell: bash
@@ -27,19 +28,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup asdf
-        uses: asdf-vm/actions/setup@v2
-
-      - name: Cache asdf
-        id: asdf-cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.asdf/
-          key: ${{ runner.os }}-${{ hashFiles('**/.tool-versions') }}
-
-      - name: Setup asdf
-        if: steps.asdf-cache.outputs.cache-hit != 'true'
-        uses: asdf-vm/actions/install@v2
+      - name: Setup rtx
+        uses: jdx/rtx-action@v1
 
       - name: "Generate documentation"
         run: ./scripts/document.sh

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,19 +21,8 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@main
 
-      - name: Setup asdf
-        uses: asdf-vm/actions/setup@v2
-
-      - name: Cache asdf
-        id: asdf-cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.asdf/
-          key: ${{ runner.os }}-${{ hashFiles('**/.tool-versions') }}
-
-      - name: Setup asdf
-        if: steps.asdf-cache.outputs.cache-hit != 'true'
-        uses: asdf-vm/actions/install@v2
+      - name: Setup rtx
+        uses: jdx/rtx-action@v1
 
       - name: "Format"
         run: ./scripts/format.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,19 +18,8 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@main
 
-      - name: Setup asdf
-        uses: asdf-vm/actions/setup@v2
-
-      - name: Cache asdf
-        id: asdf-cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.asdf/
-          key: ${{ runner.os }}-${{ hashFiles('**/.tool-versions') }}
-
-      - name: Setup asdf
-        if: steps.asdf-cache.outputs.cache-hit != 'true'
-        uses: asdf-vm/actions/install@v2
+      - name: Setup rtx
+        uses: jdx/rtx-action@v1
 
       - name: "Lint"
         run: ./scripts/lint.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,19 +10,28 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@main
 
-      - name: Setup asdf
-        uses: asdf-vm/actions/setup@v2
+      - name: Setup rtx
+        uses: jdx/rtx-action@v1
 
-      - name: Cache asdf
-        id: asdf-cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.asdf/
-          key: ${{ runner.os }}-${{ hashFiles('**/.tool-versions') }}
+      - name: "Run document script if necessary"
+        run: |
+          if [[ "$(basename "$(git rev-parse --show-toplevel)")" != *'terraform-aws-template'* ]]; then
+            ./scripts/document.sh
 
-      - name: Setup asdf
-        if: steps.asdf-cache.outputs.cache-hit != 'true'
-        uses: asdf-vm/actions/install@v2
+            echo "Setting core.fileMode to false to avoid false positives in documentation check."
+            git config core.fileMode false
+            if [[ -n $(git status --porcelain) ]]; then
+              echo "Documentation is not up to date. Comitting updates"
+
+              git add README.md
+              git config user.name "${GITHUB_USERNAME}"
+              git config user.email "${GITHUB_USERNAME}@users.noreply.github.com"
+              git commit -m "Running document script"
+            fi
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_USERNAME: ${{ github.actor }}
 
       - name: "Run document script if necessary"
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,19 +21,8 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@main
 
-      - name: Setup asdf
-        uses: asdf-vm/actions/setup@v2
-
-      - name: Cache asdf
-        id: asdf-cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.asdf/
-          key: ${{ runner.os }}-${{ hashFiles('**/.tool-versions') }}
-
-      - name: Setup asdf
-        if: steps.asdf-cache.outputs.cache-hit != 'true'
-        uses: asdf-vm/actions/install@v2
+      - name: Setup rtx
+        uses: jdx/rtx-action@v1
 
       - name: "Validate Module"
         run: ./scripts/validate.sh

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 PBS
+Copyright (c) 2023 PBS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Use this URL for the source of the module. See the usage examples below for more details.
 
 ```hcl
-github.com/pbs/terraform-aws-cloudfront-function-module?ref=0.0.19
+github.com/pbs/terraform-aws-cloudfront-function-module?ref=x.y.z
 ```
 
 ### Alternative Installation Methods
@@ -22,7 +22,7 @@ Integrate this module like so:
 
 ```hcl
 module "cloudfront-function" {
-  source = "github.com/pbs/terraform-aws-cloudfront-function-module?ref=0.0.19"
+  source = "github.com/pbs/terraform-aws-cloudfront-function-module?ref=x.y.z"
 
   code = file("function.js")
 
@@ -34,7 +34,7 @@ module "cloudfront-function" {
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`0.0.19`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 


### PR DESCRIPTION
- Bump aws from 5.4.0 to 5.6.2
- Update README for new release: 0.0.19
- Bump aws from 5.6.2 to 5.7.0
- Update README for new release: 0.0.20
- Adding step to run document script before running release script
- Update README for new release: 0.0.21
- Bump aws from 5.7.0 to 5.8.0
- Update README for new release: 0.0.22
- Bump aws from 5.8.0 to 5.9.0
- Update README for new release: 0.0.23
- Bump aws from 5.9.0 to 5.10.0
- Update README for new release: 0.0.24
- Bump aws from 5.10.0 to 5.11.0
- Update README for new release: 0.0.25
- Bump aws from 5.11.0 to 5.12.0
- Update README for new release: 0.0.26
- Updating LICENSE year to 2023
- Update README for new release: 0.0.27
- Bump aws from 5.12.0 to 5.13.1
- Update README for new release: 0.0.28
- Bump aws from 5.13.1 to 5.14.0
- Update README for new release: 0.0.29
- Bump aws from 5.14.0 to 5.15.0
- Update README for new release: 0.0.30
- Bump aws from 5.15.0 to 5.16.1
- Update README for new release: 0.0.31
- Bump aws from 5.16.1 to 5.17.0
- Update README for new release: 0.0.32
- Bump aws from 5.17.0 to 5.19.0
- Update README for new release: 0.0.33
- Bump aws from 5.19.0 to 5.20.0
- Update README for new release: 0.0.34
- Swapping asdf for rtx
- Skipping document workflow for DependaBot triggered workflows
- Update README for new release: 0.0.35
